### PR TITLE
Opensearch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="HandheldFriendly" content="true">
-    
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Sizzy">
     <link href='https://fonts.googleapis.com/css?family=Lato:100,300,400,500' rel='stylesheet' type='text/css'>
     <title>Sizzy</title>
     <script>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,10 @@
+<OpenSearchDescription 
+    xmlns="http://a9.com/-/spec/opensearch/1.1/" 
+    xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>Sizzy</ShortName>
+    <Description>Enter a URL</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/x-icon">https://sizzy.co/favicon.ico</Image>
+    <Url type="text/html" method="get" template="https://sizzy.co/?url={searchTerms}&ref=opensearch"/>
+    <moz:SearchForm>https://sizzy.co</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Opensearch lets the user search a query right from the address bar.

By adding an opensearch reference, newer browsers will let frequent users type in the URL for whatever page they want to examine, whenever they type in the sizzy.co URL.

