### PR TITLE
Add browsing history

### DIFF
--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -8,17 +8,21 @@ import ORIENTATIONS from 'config/orientations';
 
 //styled-components
 import {
-  Sidebar,
-  Filters,
+  BookmarkLink,
+  Bottom,
   ButtonIcon,
+  ButtonText,
+  Filters,
+  Label,
+  List,
+  ListItem,
+  RecentlyVisited,
+  Sidebar,
+  Sponsored,
+  ToggleSidebar,
   ToolbarButton,
   ToolbarButtons,
-  Top,
-  Label,
-  ButtonText,
-  ToggleSidebar,
-  Sponsored,
-  Bottom
+  Top
 } from './styles';
 
 //components
@@ -45,10 +49,11 @@ class SidebarComponent extends Component {
     const {store, theme} = this.props;
     const {app} = store;
     const {
-      osFilters,
+      bookmarks,
       deviceTypeFilters,
-      sidebarFullSize,
+      osFilters,
       settings,
+      sidebarFullSize,
       toggleSidebar
     } = app;
     const {zoom, orientation} = settings;
@@ -175,6 +180,29 @@ class SidebarComponent extends Component {
                 {sidebarFullSize && <ButtonText> Switch theme </ButtonText>}
               </ToolbarButton>
             </ToolbarButtons>
+
+            {sidebarFullSize && <Label>Recently visited</Label>}
+            {sidebarFullSize && (
+              <RecentlyVisited>
+                <List>
+                  {bookmarks.map(bookmarkUrl => (
+                    <ListItem>
+                      <BookmarkLink
+                        key={bookmarkUrl}
+                        title={bookmarkUrl}
+                        onClick={e => {
+                          e.preventDefault();
+                          app.url = bookmarkUrl;
+                          app.loadCurrentUrl();
+                        }}
+                      >
+                        {bookmarkUrl}
+                      </BookmarkLink>
+                    </ListItem>
+                  ))}
+                </List>
+              </RecentlyVisited>
+            )}
 
             {!sidebarFullSize && <Label> Zoom </Label>}
             {!sidebarFullSize && (

--- a/src/components/Sidebar/styles.js
+++ b/src/components/Sidebar/styles.js
@@ -24,10 +24,12 @@ export const Sidebar = styled.div`
 
 export const Filters = styled.div`
   ${p => (p.theme.sidebarFullSize ? flex.horizontal : flex.vertical)} ${p =>
-      p.theme.sidebarFullSize ? flex.centerHorizontalV : flex.centerHorizontal};
+    p.theme.sidebarFullSize ? flex.centerHorizontalV : flex.centerHorizontal};
 `;
 
-export const Top = styled.div`${flex.vertical};`;
+export const Top = styled.div`
+  ${flex.vertical};
+`;
 
 export const Label = styled.div`
   ${noSelect} font-size: ${p => (p.theme.sidebarFullSize ? 13 : 11)}px;
@@ -35,17 +37,51 @@ export const Label = styled.div`
   ${p => cond(!p.theme.sidebarFullSize, `text-align: center;`)} margin: 15px 0;
 `;
 
-export const ToolbarButtons = styled.div`${flex.vertical} width: 100%;`;
+export const ToolbarButtons = styled.div`
+  ${flex.vertical} width: 100%;
+`;
+
+export const RecentlyVisited = styled.div`
+  ${flex.vertical} width: 100%;
+`;
+
+export const List = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+export const ListItem = styled.li`
+  list-style: none;
+  margin: 0;
+  overflow: hidden;
+  padding: 3px 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const BookmarkLink = styled.a`
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  font-size: 13px;
+
+  &:hover {
+    text-decoration: underline;
+    &:hover {
+      background-color: #1d2027;
+    }
+  }
+`;
 
 /* Button */
 export const ToolbarButton = styled.div`
   ${flex.horizontal} ${p =>
-      p.theme.sidebarFullSize
-        ? flex.centerHorizontalV
-        : flex.centerHorizontal} ${p =>
-      p.theme.sidebarFullSize
-        ? `margin-right: 10px;`
-        : `margin-bottom: 7px;`} ${noSelect} min-width: 40px;
+  p.theme.sidebarFullSize
+    ? flex.centerHorizontalV
+    : flex.centerHorizontal} ${p =>
+  p.theme.sidebarFullSize
+    ? `margin-right: 10px;`
+    : `margin-bottom: 7px;`} ${noSelect} min-width: 40px;
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
   font-size: 13px;
   border-radius: 3px;
@@ -68,7 +104,7 @@ export const ButtonIcon = styled($Icon)`
   font-size: 18px !important;
   transition: ${colorTransition};
   ${rotateIconOnOrientationChange} ${p =>
-      cond(p.theme.sidebarFullSize, `margin-right: 8px;`)} min-width: 25px;
+    cond(p.theme.sidebarFullSize, `margin-right: 8px;`)} min-width: 25px;
   opacity: 0.7;
 `;
 
@@ -97,7 +133,9 @@ export const ToggleSidebar = styled($Icon)`
   }
 `;
 
-export const Bottom = styled.div`${flex.vertical};`;
+export const Bottom = styled.div`
+  ${flex.vertical};
+`;
 
 export const Sponsored = styled.a`
   text-decoration: none;

--- a/src/components/WelcomeBox/index.js
+++ b/src/components/WelcomeBox/index.js
@@ -67,7 +67,12 @@ class WelcomeBoxComponent extends Component {
             at once.
           </MobileText>
 
-          <OnlyAvailable>It's only available on large devices 😞</OnlyAvailable>
+          <OnlyAvailable>
+            It's only available on large devices{' '}
+            <span role="img" aria-label="Sadface">
+              😞
+            </span>
+          </OnlyAvailable>
 
           <ThemeProvider theme={themes.dark}>
             <UrlBar styles={UrlInputStyles} />
@@ -94,8 +99,7 @@ class WelcomeBoxComponent extends Component {
           )}
         </Content>
 
-        {!loading &&
-        !window.isElectron && (
+        {!loading && !window.isElectron && (
           <MadeBy target="_blank" href="https://kitze.io">
             made by @thekitze
           </MadeBy>

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,2 +1,3 @@
 export const IS_LOCAL_DEV = window.location.hostname === 'localhost';
 export const LOADING_TIME_MS = IS_LOCAL_DEV ? 100 : 1800;
+export const LOCAL_STORAGE_BOOKMARKS_KEY = 'sizzy-bookmarks';

--- a/src/config/faq-questions.js
+++ b/src/config/faq-questions.js
@@ -6,21 +6,21 @@ const questions = [
     title: 'Why are some sites showing as a blank white box?',
     answer: (
       <div>
-        Some websites are configured to prevent embedding into another site. Sizzy is showing the "devices" by embedding a website in multiple iframes.
-        Unfortunately, this is configured from their side and there's nothing we can do about it, at least in the web version of Sizzy.
-        The
-
-        {' '}
+        Some websites are configured to prevent embedding into another site.
+        Sizzy is showing the "devices" by embedding a website in multiple
+        iframes. Unfortunately, this is configured from their side and there's
+        nothing we can do about it, at least in the web version of Sizzy. The{' '}
         <a
           target="_blank"
+          rel="noopener noreferrer"
           href="https://chrome.google.com/webstore/detail/sizzy/nfhlbmjiiogoelaflfclodlkncbdiefo"
         >
           Chrome Extension
-        </a>
-        {' '}
-
+        </a>{' '}
         can overcome this problem on
-        <i><b> some </b></i>
+        <i>
+          <b> some </b>
+        </i>
         websites, but not on all of them.
       </div>
     )
@@ -30,18 +30,19 @@ const questions = [
     title: 'How does Sizzy compare to an actual device?',
     answer: (
       <div>
-        The app is missing a few core features in order to represent 100% of what's on an actual device:
+        The app is missing a few core features in order to represent 100% of
+        what's on an actual device:
         <ul>
           <li>
-
-            Simulate real user agents (some devices aren't using media queries to optimize a mobile website, but are switching between desktop/mobile version based on the user agent)
-
+            Simulate real user agents (some devices aren't using media queries
+            to optimize a mobile website, but are switching between
+            desktop/mobile version based on the user agent)
           </li>
           <li> Take into consideration device pixel ratio </li>
           <li> Scrollbars of the devices (iframes) are using viewport size </li>
         </ul>
-
-        All of these issues will be fixed soon, but for now it would be good to do few final tests on a real device.
+        All of these issues will be fixed soon, but for now it would be good to
+        do few final tests on a real device.
       </div>
     )
   },
@@ -50,9 +51,14 @@ const questions = [
     title: `Why isn't the scroll synchronized between devices?`,
     answer: (
       <div>
-        For now, it doesn't make sense because there's a mix of various devices and sizes which can either be in portrait on landscape.
-        Imagine a situation where you have a huge iPad and a small iPhone next to it and the scroll is synchronized, with one scroll on the iPhone, you're going to reach the end of the site on the iPad.
-        So the scroll won't really be "synced". This feature won't be implemented until there's a proper solution where the scroll is not actually "synced", but it's focusing on the same portion of the page on all devices.
+        For now, it doesn't make sense because there's a mix of various devices
+        and sizes which can either be in portrait on landscape. Imagine a
+        situation where you have a huge iPad and a small iPhone next to it and
+        the scroll is synchronized, with one scroll on the iPhone, you're going
+        to reach the end of the site on the iPad. So the scroll won't really be
+        "synced". This feature won't be implemented until there's a proper
+        solution where the scroll is not actually "synced", but it's focusing on
+        the same portion of the page on all devices.
       </div>
     )
   },
@@ -62,8 +68,10 @@ const questions = [
     title: 'Why are my settings lost after a refresh?',
     answer: (
       <div>
-        Right now nothing is persisted in the local storage. So everything that you configure and change is just temporary.
-        The feature of persisting the user settings in the local storage is coming soon and it has a high priority on the roadmap.
+        Right now nothing is persisted in the local storage. So everything that
+        you configure and change is just temporary. The feature of persisting
+        the user settings in the local storage is coming soon and it has a high
+        priority on the roadmap.
       </div>
     )
   },
@@ -72,8 +80,10 @@ const questions = [
     title: 'How can I add, remove, or edit devices?',
     answer: (
       <div>
-        For now the list of devices is static and cannot be changed. A bunch of new devices will be added soon, and the feature for adding/removing/configuring devices
-        should come after the feature for persisting the user settings in the local storage.
+        For now the list of devices is static and cannot be changed. A bunch of
+        new devices will be added soon, and the feature for
+        adding/removing/configuring devices should come after the feature for
+        persisting the user settings in the local storage.
       </div>
     )
   },
@@ -82,19 +92,24 @@ const questions = [
     title: 'Can I test local websites?',
     answer: (
       <div>
-        Yes you can.
-
-        If you're running a local server, just paste http://localhost:3000, or whatever the link of your local webserver is, into the url bar of Sizzy.
-        Keep in mind that the link must start with https:// or http://.
-        You cannot point to an index.html file that's starting with file://.
-        If you need a simple server to run your local files you can use
-
-        <a href="https://www.npmjs.com/package/http-server" target="_blank">
-          {' '}http-server{' '}
+        Yes you can. If you're running a local server, just paste
+        http://localhost:3000, or whatever the link of your local webserver is,
+        into the url bar of Sizzy. Keep in mind that the link must start with
+        https:// or http://. You cannot point to an index.html file that's
+        starting with file://. If you need a simple server to run your local
+        files you can use
+        <a
+          href="https://www.npmjs.com/package/http-server"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {' '}
+          http-server{' '}
         </a>
-
-        (a zero-configuration command-line http server).
-        Just start http-server, point it to the folder of your website and it will serve your app on http://localhost:8080. Then you can paste http://localhost:8080 in the url bar of Sizzy.
+        (a zero-configuration command-line http server). Just start http-server,
+        point it to the folder of your website and it will serve your app on
+        http://localhost:8080. Then you can paste http://localhost:8080 in the
+        url bar of Sizzy.
       </div>
     )
   },
@@ -103,14 +118,18 @@ const questions = [
     title: `Why is Webpack + Hot Module Reloading not working?`,
     answer: (
       <div>
-        The problem is better explained in {' '}<a
+        The problem is better explained in{' '}
+        <a
           href="https://github.com/kitze/sizzy/issues/21"
           target="_blank"
+          rel="noopener noreferrer"
         >
           this issue
-        </a>{' '} on GitHub.
-        Basically HMR in Webpack doesn't work accross different domains, so when you're developing an app locally and previewing it on Sizzy, HMR breaks (you can see the errors in the console).
-        Hopefully we'll find a fix for this soon.
+        </a>{' '}
+        on GitHub. Basically HMR in Webpack doesn't work accross different
+        domains, so when you're developing an app locally and previewing it on
+        Sizzy, HMR breaks (you can see the errors in the console). Hopefully
+        we'll find a fix for this soon.
       </div>
     )
   },
@@ -119,45 +138,40 @@ const questions = [
     title: `Why does the Chrome Extension need a permission to read data on all websites?`,
     answer: (
       <div>
-        First of all, you can keep your piece of mind because the extension is
-
-        {' '}
+        First of all, you can keep your piece of mind because the extension is{' '}
         <a
           href="https://github.com/kitze/sizzy/tree/master/chrome-extension"
           target="_blank"
+          rel="noopener noreferrer"
         >
           open sourced
         </a>
         {', '}
-
-        so you can explore it and see what it does.
-
-        The extension has 2 basic functionalities:
+        so you can explore it and see what it does. The extension has 2 basic
+        functionalities:
         <ol>
           <li>
-            When clicking the "S" button in the toolbar, it opens the current website in Sizzy.
+            When clicking the "S" button in the toolbar, it opens the current
+            website in Sizzy.
           </li>
           <li>
-            It blocks "x-frame-options" headers from the requests, so you can embed most of the websites that prevent embedding.
-
+            It blocks "x-frame-options" headers from the requests, so you can
+            embed most of the websites that prevent embedding.
           </li>
         </ol>
-
-        In order to block the headers from some requests, Chrome requires
-
-        {' '}
+        In order to block the headers from some requests, Chrome requires{' '}
         <a
           href="https://github.com/kitze/sizzy/blob/master/chrome-extension/manifest.json#L19"
           target="_blank"
+          rel="noopener noreferrer"
         >
           the following permissions:
-        </a>
-        {' '}
-
-        {`"[ "activeTab", "webRequest", "webRequestBlocking", "<all_urls>" ]`}
-
-        I would understand your concern if the extension had a closed source, but in this case you have nothing to worry about.
-        If you're not very technical and you need a further explanation, feel free to contact me anywhere!
+        </a>{' '}
+        {`"[ "activeTab", "webRequest", "webRequestBlocking", "<all_urls>" ]`}I
+        would understand your concern if the extension had a closed source, but
+        in this case you have nothing to worry about. If you're not very
+        technical and you need a further explanation, feel free to contact me
+        anywhere!
       </div>
     )
   },
@@ -166,16 +180,13 @@ const questions = [
     title: `I really like Sizzy! How can I make sure that it will stick around and be updated with awesome new features?`,
     answer: (
       <div>
-        Currently, this project is being developed mostly
-
-        {' '}
+        Currently, this project is being developed mostly{' '}
         <a href="https://kitze.io" target="_blank" rel="noopener noreferrer">
           by 1 person
         </a>
         {'. '}
-        Development will continue as usual but it would help greatly if you support this project with a one-time, or a recurring donation
-
-        {' '}
+        Development will continue as usual but it would help greatly if you
+        support this project with a one-time, or a recurring donation{' '}
         <a
           target="_blank"
           rel="noopener noreferrer"
@@ -184,15 +195,12 @@ const questions = [
           on OpenCollective
         </a>
         {'. '}
-
-        If you would like to discuss about a different way of supporting Sizzy, you can
-
-        {' '}
+        If you would like to discuss about a different way of supporting Sizzy,
+        you can{' '}
         <a target="_blank" rel="noopener noreferrer" href="https://kitze.io">
           contact me here
         </a>
         {'. '}
-
       </div>
     )
   }

--- a/src/mobx-router/src/regex.js
+++ b/src/mobx-router/src/regex.js
@@ -1,2 +1,2 @@
-export const paramRegex = /\/(:([^\/?]*)\??)/g;
-export const optionalRegex = /(\/:[^\/]*\?)$/g;
+export const paramRegex = /\/(:([^/?]*)\??)/g;
+export const optionalRegex = /(\/:[^/]*\?)$/g;

--- a/src/mobx-router/src/utils.js
+++ b/src/mobx-router/src/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-cond-assign */
 export const isObject = obj =>
   obj && typeof obj === 'object' && !Array.isArray(obj);
 export const getObjectKeys = obj => (isObject(obj) ? Object.keys(obj) : []);

--- a/src/stores/app-store.js
+++ b/src/stores/app-store.js
@@ -3,6 +3,7 @@ import type {DeviceSettings, MeasureObject} from 'config/types';
 import {observable, action, computed} from 'mobx';
 import {isWebUri} from 'valid-url';
 import {isUrlSameProtocol, getOppositeProtocol} from 'utils/url-utils';
+import {saveBookmark, loadBookmarks} from 'utils/storage-utils';
 import allDevices from 'config/devices';
 import store from 'stores/store';
 import views from 'config/views';
@@ -40,6 +41,7 @@ class AppStore {
   @observable
   devices: Array<Device> = map(allDevices, device => new Device(device));
   settings: Settings = new Settings(true);
+  @observable bookmarks: Array<string> = loadBookmarks();
 
   /* Actions */
 
@@ -169,9 +171,9 @@ class AppStore {
 
       //if invalid url (doesn't have protcol), try to append current protocol
       if (!isWebUri(urlToLoad)) {
-        const urlWithProtocol = `${window.isElectron
-          ? 'http:'
-          : protocol}//${urlToLoad}`;
+        const urlWithProtocol = `${
+          window.isElectron ? 'http:' : protocol
+        }//${urlToLoad}`;
         urlToLoad = urlWithProtocol;
       }
 
@@ -196,6 +198,9 @@ class AppStore {
       if (insertIntoUrl && !window.isElectron) {
         store.router.goTo(views.home, {}, store, {url: this.urlToLoad});
       }
+
+      saveBookmark(this.url);
+      this.bookmarks = loadBookmarks();
     }
   };
 
@@ -236,9 +241,9 @@ class AppStore {
 
   @action
   loadExampleUrl = () => {
-    const exampleUrl = `${window.isElectron
-      ? 'http:'
-      : window.location.protocol}//reactacademy.io`;
+    const exampleUrl = `${
+      window.isElectron ? 'http:' : window.location.protocol
+    }//reactacademy.io`;
     this.setUrl(exampleUrl);
     this.setUrltoLoad(exampleUrl, false, true);
   };

--- a/src/utils/storage-utils.js
+++ b/src/utils/storage-utils.js
@@ -1,0 +1,48 @@
+import {LOCAL_STORAGE_BOOKMARKS_KEY} from 'config/constants';
+
+const localStorageIsSupported = () => {
+  try {
+    return 'localStorage' in window && window['localStorage'] !== null;
+  } catch (e) {
+    return false;
+  }
+};
+
+const save = (key, value) => {
+  if (localStorageIsSupported()) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (e) {
+      console.warn('Local Storage not supported');
+    }
+  }
+};
+
+const get = key => {
+  if (localStorageIsSupported()) {
+    try {
+      var data = window.localStorage.getItem(key);
+      if (data && typeof data === 'object') {
+        return JSON.parse(data);
+      } else {
+        return data;
+      }
+    } catch (e) {
+      console.warn('Local Storage not supported');
+    }
+  }
+  return null;
+};
+
+export const saveBookmark = url => {
+  const bookmarks = loadBookmarks();
+  if (!bookmarks.includes(url)) {
+    bookmarks.unshift(url);
+    bookmarks.pop();
+    save(LOCAL_STORAGE_BOOKMARKS_KEY, JSON.stringify(bookmarks));
+  }
+};
+
+export const loadBookmarks = () => {
+  return JSON.parse(get(LOCAL_STORAGE_BOOKMARKS_KEY)) || [];
+};

--- a/src/utils/storage-utils.js
+++ b/src/utils/storage-utils.js
@@ -37,9 +37,8 @@ const get = key => {
 export const saveBookmark = url => {
   const bookmarks = loadBookmarks();
   if (!bookmarks.includes(url)) {
-    bookmarks = bookmarks.slice(0,2);
     bookmarks.unshift(url);
-    save(LOCAL_STORAGE_BOOKMARKS_KEY, JSON.stringify(bookmarks));
+    save(LOCAL_STORAGE_BOOKMARKS_KEY, JSON.stringify(bookmarks.slice(0, 2)));
   }
 };
 

--- a/src/utils/storage-utils.js
+++ b/src/utils/storage-utils.js
@@ -37,8 +37,8 @@ const get = key => {
 export const saveBookmark = url => {
   const bookmarks = loadBookmarks();
   if (!bookmarks.includes(url)) {
+    bookmarks = bookmarks.slice(0,2);
     bookmarks.unshift(url);
-    bookmarks.pop();
     save(LOCAL_STORAGE_BOOKMARKS_KEY, JSON.stringify(bookmarks));
   }
 };


### PR DESCRIPTION
# Add browsing history

So, it would be nice to see the url that have been used recently as pretty much all of us must be testing a small list  of websites.

If you run this branch you can see Idea 2 in place.

The solution is adding some new utils to save into local storage and update the state consequently.

## Idea 1 - Add the list of recently visited website as a small panel showing on input focus.

<img width="1355" alt="idea1" src="https://user-images.githubusercontent.com/1746646/54094255-89a62300-4397-11e9-8bc1-5ae2c6b674d1.png">

## Idea 2 - Add the list of recently visited website in the sidebar, here I would say to list only the last 3 websites visited.

<img width="823" alt="idea2" src="https://user-images.githubusercontent.com/1746646/54094282-b8bc9480-4397-11e9-9f6a-1f3ae71d23b1.png">

